### PR TITLE
Readme: clone before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ conda activate betterfs2
 2. Install from source
 
 ```bash
-pip install git+https://github.com/shivammehta25/BetterFastSpeech2.git
+git clone https://github.com/shivammehta25/BetterFastSpeech2.git
 cd BetterFastSpeech2
 pip install -e .
 ```


### PR DESCRIPTION
In the `install` section, the instructions leads the user to install the repo twice.
The edit changes it to clone before `editable install`.